### PR TITLE
Feat add support for other two pots

### DIFF
--- a/src/MCP4251.cpp
+++ b/src/MCP4251.cpp
@@ -87,7 +87,7 @@ void MCP4251::DigitalPotWiperDecrement(uint8_t potNum)
     ::digitalWrite(_slaveSelectPin, HIGH);
 }
 
-void MCP4251::DigitalPotSetWiperPosition(bool potNum, unsigned int value)
+void MCP4251::DigitalPotSetWiperPosition(uint8_t potNum, uint16_t value)
 {
     byte cmdByte = B00000000;
     byte dataByte = B00000000;

--- a/src/MCP4251.cpp
+++ b/src/MCP4251.cpp
@@ -2,7 +2,7 @@
 #include <SPI.h>
 
 // Instantiation of object
-MCP4251::MCP4251(uint8_t slaveSelectPin, float pot0ResistanceRmax, float pot0ResistanceRmin, float pot1ResistanceRmax, float pot1ResistanceRmin)
+MCP4251::MCP4251(uint8_t slaveSelectPin, float pot0ResistanceRmax, float pot0ResistanceRmin, float pot1ResistanceRmax, float pot1ResistanceRmin, float pot2ResistanceRmax, float pot2ResistanceRmin, float pot3ResistanceRmax, float pot3ResistanceRmin)
 {
     this->_slaveSelectPin = slaveSelectPin;
 
@@ -15,6 +15,16 @@ MCP4251::MCP4251(uint8_t slaveSelectPin, float pot0ResistanceRmax, float pot0Res
     this->_pot1ResistanceRmin = pot1ResistanceRmin;
     this->_pot1ResistanceRAB = pot1ResistanceRmax - pot1ResistanceRmin;
     this->_pot1ResistanceRW = pot1ResistanceRmin;
+
+    this->_pot2ResistanceRmax = pot2ResistanceRmax;
+    this->_pot2ResistanceRmin = pot2ResistanceRmin;
+    this->_pot2ResistanceRAB = pot2ResistanceRmax - pot2ResistanceRmin;
+    this->_pot2ResistanceRW = pot2ResistanceRmin;
+
+    this->_pot3ResistanceRmax = pot3ResistanceRmax;
+    this->_pot3ResistanceRmin = pot3ResistanceRmin;
+    this->_pot3ResistanceRAB = pot3ResistanceRmax - pot3ResistanceRmin;
+    this->_pot3ResistanceRW = pot3ResistanceRmin;
 }
 
 void MCP4251::begin()
@@ -25,39 +35,55 @@ void MCP4251::begin()
     this->DigitalPotInitTcon();
     this->DigitalPotSetWiperMin(0);
     this->DigitalPotSetWiperMin(1);
+    this->DigitalPotSetWiperMin(3);
+    this->DigitalPotSetWiperMin(4);
 }
 
-void MCP4251::DigitalPotWiperIncrement(bool potNum)
+void MCP4251::DigitalPotWiperIncrement(uint8_t potNum)
 {
     byte cmdByte = B00000000;
     ::digitalWrite(_slaveSelectPin, LOW);
-    if (potNum)
-    {
-        cmdByte = ADDRESS_WIPER_1 | COMMAND_INCREMENT;
-        SPI.transfer(cmdByte);
-    }
-    else
+    if(potNum == 0)
     {
         cmdByte = ADDRESS_WIPER_0 | COMMAND_INCREMENT;
-        SPI.transfer(cmdByte);
     }
+    else if(potNum == 1)
+    {
+        cmdByte = ADDRESS_WIPER_1 | COMMAND_INCREMENT;
+    }
+    if(potNum == 2)
+    {
+        cmdByte = ADDRESS_WIPER_2 | COMMAND_INCREMENT;
+    }
+    else if(potNum == 3)
+    {
+        cmdByte = ADDRESS_WIPER_3 | COMMAND_INCREMENT;        
+    }
+    SPI.transfer(cmdByte);
     ::digitalWrite(_slaveSelectPin, HIGH);
 }
 
-void MCP4251::DigitalPotWiperDecrement(bool potNum)
+void MCP4251::DigitalPotWiperDecrement(uint8_t potNum)
 {
     byte cmdByte = B00000000;
     ::digitalWrite(_slaveSelectPin, LOW);
-    if (potNum)
-    {
-        cmdByte = ADDRESS_WIPER_1 | COMMAND_DECREMENT;
-        SPI.transfer(cmdByte);
-    }
-    else
+    if(potNum == 0)
     {
         cmdByte = ADDRESS_WIPER_0 | COMMAND_DECREMENT;
-        SPI.transfer(cmdByte);
     }
+    else if(potNum == 1)
+    {
+        cmdByte = ADDRESS_WIPER_1 | COMMAND_DECREMENT;
+    }
+    else if(potNum == 2)
+    {
+        cmdByte = ADDRESS_WIPER_2 | COMMAND_DECREMENT;
+    }
+    else if(potNum == 3)
+    {
+        cmdByte = ADDRESS_WIPER_3 | COMMAND_DECREMENT;
+    }
+    SPI.transfer(cmdByte);
     ::digitalWrite(_slaveSelectPin, HIGH);
 }
 
@@ -66,67 +92,74 @@ void MCP4251::DigitalPotSetWiperPosition(bool potNum, unsigned int value)
     byte cmdByte = B00000000;
     byte dataByte = B00000000;
     if (value > 255)
+    {
         cmdByte |= B00000001;
+    }
     else
+    {
         dataByte = (byte)(value & 0X00FF);
+    }
     ::digitalWrite(_slaveSelectPin, LOW);
-    if (potNum)
+    if(potNum == 0)
+    {
+        cmdByte = cmdByte | ADDRESS_WIPER_0 | COMMAND_WRITE;        
+    }
+    else if(potNum == 1)
     {
         cmdByte = cmdByte | ADDRESS_WIPER_1 | COMMAND_WRITE;
-        SPI.transfer(cmdByte);
-        SPI.transfer(dataByte);
     }
-    else
+    else if(potNum == 2)
     {
-        cmdByte = cmdByte | ADDRESS_WIPER_0 | COMMAND_WRITE;
-        SPI.transfer(cmdByte);
-        SPI.transfer(dataByte);
+        cmdByte = cmdByte | ADDRESS_WIPER_2 | COMMAND_WRITE;        
     }
+    else if(potNum == 3)
+    {
+        cmdByte = cmdByte | ADDRESS_WIPER_3 | COMMAND_WRITE;
+    }
+    SPI.transfer(cmdByte);
+    SPI.transfer(dataByte);
     ::digitalWrite(_slaveSelectPin, HIGH);
 }
 
-void MCP4251::DigitalPotSetWiperMin(bool potNum)
+void MCP4251::DigitalPotSetWiperMin(uint8_t potNum)
 {
-    if (potNum)
-        DigitalPotSetWiperPosition(1, 0);
-    else
-        DigitalPotSetWiperPosition(0, 0);
+    DigitalPotSetWiperPosition(potNum, 0);
 }
 
-void MCP4251::DigitalPotSetWiperMax(bool potNum)
+void MCP4251::DigitalPotSetWiperMax(uint8_t potNum)
 {
-    if (potNum)
-        DigitalPotSetWiperPosition(1, 256);
-    else
-        DigitalPotSetWiperPosition(0, 256);
+    DigitalPotSetWiperPosition(potNum, 256);
 }
 
-void MCP4251::DigitalPotSetWiperMid(bool potNum)
+void MCP4251::DigitalPotSetWiperMid(uint8_t potNum)
 {
-    if (potNum)
-        DigitalPotSetWiperPosition(1, 128);
-    else
-        DigitalPotSetWiperPosition(0, 128);
+    DigitalPotSetWiperPosition(potNum, 128);
 }
 
-uint16_t MCP4251::DigitalPotReadWiperPosition(bool potNum)
+uint16_t MCP4251::DigitalPotReadWiperPosition(uint8_t potNum)
 {
     byte cmdByte = B00000000;
     byte hByte = B00000000;
     byte lByte = B00000000;
     ::digitalWrite(_slaveSelectPin, LOW);
-    if (potNum)
-    {
-        cmdByte = ADDRESS_WIPER_1 | COMMAND_READ;
-        hByte = SPI.transfer(cmdByte);
-        lByte = SPI.transfer(DUMMY_DATA);
-    }
-    else
+    if(potNum == 0)
     {
         cmdByte = ADDRESS_WIPER_0 | COMMAND_READ;
-        hByte = SPI.transfer(cmdByte);
-        lByte = SPI.transfer(DUMMY_DATA);
     }
+    else if(potNum == 1)
+    {
+        cmdByte = ADDRESS_WIPER_1 | COMMAND_READ;
+    }
+    else if(potNum == 2)
+    {
+        cmdByte = ADDRESS_WIPER_2 | COMMAND_READ;
+    }
+    else if(potNum == 3)
+    {
+        cmdByte = ADDRESS_WIPER_3 | COMMAND_READ;
+    }
+    hByte = SPI.transfer(cmdByte);
+    lByte = SPI.transfer(DUMMY_DATA);
     ::digitalWrite(_slaveSelectPin, HIGH);
     return ((uint16_t)hByte << 8 | (uint16_t)lByte) & BITMASK_READ_DATA_REGISTER;
 }
@@ -150,146 +183,321 @@ uint16_t MCP4251::DigitalPotReadTconRegister()
     byte hByte = B00000000;
     byte lByte = B00000000;
     ::digitalWrite(_slaveSelectPin, LOW);
-    cmdByte = ADDRESS_TCON | COMMAND_READ;
+    cmdByte = ADDRESS_TCON0 | COMMAND_READ;
     hByte = SPI.transfer(cmdByte);
     lByte = SPI.transfer(DUMMY_DATA);
     ::digitalWrite(_slaveSelectPin, HIGH);
     return ((uint16_t)hByte << 8 | (uint16_t)lByte) & BITMASK_READ_DATA_REGISTER;
 }
 
-void MCP4251::DigitalPotWriteTconRegister(uint16_t value)
+void MCP4251::DigitalPotWriteTcon0Register(uint16_t value)
 {
     byte cmdByte = B00000000;
     byte dataByte = B00000000;
     if (value > 255)
+    {
         cmdByte |= B00000001;
+    }
     else
+    {
         dataByte = (byte)(value & 0X00FF);
+    }
     ::digitalWrite(_slaveSelectPin, LOW);
-    cmdByte = cmdByte | ADDRESS_TCON | COMMAND_WRITE;
+    cmdByte = cmdByte | ADDRESS_TCON0 | COMMAND_WRITE;
     SPI.transfer(cmdByte);
     SPI.transfer(dataByte);
     ::digitalWrite(_slaveSelectPin, HIGH);
 }
 
-void MCP4251::DigitalPotStartup(bool potNum)
+void MCP4251::DigitalPotWriteTcon1Register(uint16_t value)
+{
+    byte cmdByte = B00000000;
+    byte dataByte = B00000000;
+    if (value > 255)
+    {
+        cmdByte |= B00000001;
+    }
+    else
+    {
+        dataByte = (byte)(value & 0X00FF);
+    }
+    ::digitalWrite(_slaveSelectPin, LOW);
+    cmdByte = cmdByte | ADDRESS_TCON1 | COMMAND_WRITE;
+    SPI.transfer(cmdByte);
+    SPI.transfer(dataByte);
+    ::digitalWrite(_slaveSelectPin, HIGH);
+}
+
+void MCP4251::DigitalPotStartup(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte | BITMASK_POT1_STARTUP;
-    else
+    if(potNum == 0)
+    {
         lByte = lByte | BITMASK_POT0_STARTUP;
+    }
+    else if(potNum == 1)
+    {
+        lByte = lByte | BITMASK_POT1_STARTUP;
+    }
+    else if(potNum == 2)
+    {
+        lByte = lByte | BITMASK_POT2_STARTUP;
+    }
+    else if(potNum == 3)
+    {
+        lByte = lByte | BITMASK_POT3_STARTUP;
+    }
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
-void MCP4251::DigitalPotShutdown(bool potNum)
+void MCP4251::DigitalPotShutdown(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte & ~BITMASK_POT1_STARTUP;
-    else
+    if(potNum == 0)
+    {
         lByte = lByte & ~BITMASK_POT0_STARTUP;
-
+    }
+    else if(potNum == 1)
+    {
+        lByte = lByte & ~BITMASK_POT1_STARTUP;
+    }
+    else if(potNum == 2)
+    {
+        lByte = lByte & ~BITMASK_POT2_STARTUP;
+    }
+    else if(potNum == 3)
+    {
+        lByte = lByte & ~BITMASK_POT3_STARTUP;
+    }
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
-void MCP4251::DigitalPotTerminalBConnect(bool potNum)
+void MCP4251::DigitalPotTerminalBConnect(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte | BITMASK_POT1_B_TERMINAL_CONNECT;
-    else
+    if(potNum == 0)
+    {
         lByte = lByte | BITMASK_POT0_B_TERMINAL_CONNECT;
+    }
+    else if(potNum == 1)
+    {
+        lByte = lByte | BITMASK_POT1_B_TERMINAL_CONNECT;
+    }
+    else if(potNum == 2)
+    {
+        lByte = lByte | BITMASK_POT2_B_TERMINAL_CONNECT;
+    }
+    else if(potNum == 3)
+    {
+        lByte = lByte | BITMASK_POT3_B_TERMINAL_CONNECT;
+    }    
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
-void MCP4251::DigitalPotTerminalBDisconnect(bool potNum)
+void MCP4251::DigitalPotTerminalBDisconnect(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte & ~BITMASK_POT1_B_TERMINAL_CONNECT;
-    else
+    if (potNum == 0)
+    {
         lByte = lByte & ~BITMASK_POT0_B_TERMINAL_CONNECT;
+    } 
+    else if(potNum == 1)
+    {
+        lByte = lByte & ~BITMASK_POT1_B_TERMINAL_CONNECT;
+    }
+    else if (potNum == 2)
+    {
+        lByte = lByte & ~BITMASK_POT2_B_TERMINAL_CONNECT;
+    } 
+    else if(potNum == 3)
+    {
+        lByte = lByte & ~BITMASK_POT3_B_TERMINAL_CONNECT;
+    }
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
-void MCP4251::DigitalPotTerminalAConnect(bool potNum)
+void MCP4251::DigitalPotTerminalAConnect(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte | BITMASK_POT1_A_TERMINAL_CONNECT;
-    else
+    if(potNum == 0)
+    {
         lByte = lByte | BITMASK_POT0_A_TERMINAL_CONNECT;
+    }
+    else if(potNum == 1)
+    {
+        lByte = lByte | BITMASK_POT1_A_TERMINAL_CONNECT;
+    }
+    else if(potNum == 2)
+    {
+        lByte = lByte | BITMASK_POT2_A_TERMINAL_CONNECT;
+    }
+    else if(potNum == 3)
+    {
+        lByte = lByte | BITMASK_POT3_A_TERMINAL_CONNECT;
+    }
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
-void MCP4251::DigitalPotTerminalADisconnect(bool potNum)
+void MCP4251::DigitalPotTerminalADisconnect(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte & ~BITMASK_POT1_A_TERMINAL_CONNECT;
-    else
+    if(potNum == 0)
+    {
         lByte = lByte & ~BITMASK_POT0_A_TERMINAL_CONNECT;
+    }
+    else if(potNum == 1)
+    {
+        lByte = lByte & ~BITMASK_POT1_A_TERMINAL_CONNECT;
+    }
+    else if(potNum == 2)
+    {
+        lByte = lByte & ~BITMASK_POT2_A_TERMINAL_CONNECT;
+    }
+    else if(potNum == 3)
+    {
+        lByte = lByte & ~BITMASK_POT3_A_TERMINAL_CONNECT;
+    }
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
-void MCP4251::DigitalPotWiperConnect(bool potNum)
+void MCP4251::DigitalPotWiperConnect(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte | BITMASK_POT1_WIPER_TERMINAL_CONNECT;
-    else
+    if(potNum == 0)
+    {
         lByte = lByte | BITMASK_POT0_WIPER_TERMINAL_CONNECT;
+    }
+    else if(potNum == 1)
+    {
+        lByte = lByte | BITMASK_POT1_WIPER_TERMINAL_CONNECT;
+    }
+    if(potNum == 2)
+    {
+        lByte = lByte | BITMASK_POT2_WIPER_TERMINAL_CONNECT;
+    }
+    else if(potNum == 3)
+    {
+        lByte = lByte | BITMASK_POT3_WIPER_TERMINAL_CONNECT;
+    }
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
-void MCP4251::DigitalPotWiperDisconnect(bool potNum)
+void MCP4251::DigitalPotWiperDisconnect(uint8_t potNum)
 {
     uint16_t tconData = this->DigitalPotReadTconRegister();
     byte hByte = (uint8_t)tconData >> 8;
     byte lByte = (uint8_t)tconData & 0xff;
 
-    if (potNum)
-        lByte = lByte & ~BITMASK_POT1_WIPER_TERMINAL_CONNECT;
-    else
+    if(potNum == 0)
+    {
         lByte = lByte & ~BITMASK_POT0_WIPER_TERMINAL_CONNECT;
+    }
+    else if(potNum == 1)
+    {
+        lByte = lByte & ~BITMASK_POT1_WIPER_TERMINAL_CONNECT;
+    }
+    else if(potNum == 2)
+    {
+        lByte = lByte & ~BITMASK_POT2_WIPER_TERMINAL_CONNECT;
+    }
+    else if(potNum == 3)
+    {
+        lByte = lByte & ~BITMASK_POT3_WIPER_TERMINAL_CONNECT;
+    }
+
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    if(potNum < 2)
+    {
+        this->DigitalPotWriteTcon0Register(tconData);
+    }
+    else
+    {
+        this->DigitalPotWriteTcon1Register(tconData);
+    }
 }
 
 void MCP4251::DigitalPotInitTcon()
@@ -301,50 +509,112 @@ void MCP4251::DigitalPotInitTcon()
     lByte = lByte | DUMMY_DATA;
 
     tconData = (uint16_t)hByte << 8 | (uint16_t)lByte;
-    this->DigitalPotWriteTconRegister(tconData);
+    this->DigitalPotWriteTcon0Register(tconData);
+    this->DigitalPotWriteTcon1Register(tconData);
+    
 }
 
-uint16_t MCP4251::DigitalPotResistanceToPosition(bool potNum, float resistance)
+uint16_t MCP4251::DigitalPotResistanceToPosition(uint8_t potNum, float resistance)
 {
-    if (potNum)
-    {
-        if (resistance <= this->_pot1ResistanceRmin)
-            return 0;
-        else if (resistance > this->_pot1ResistanceRmax)
-            return 256;
-
-        return (uint16_t)((((resistance - this->_pot1ResistanceRW) / (this->_pot1ResistanceRAB)) * (float)256) + 0.5);
-    }
-    else
+    if(potNum == 0)
     {
         if (resistance <= this->_pot0ResistanceRmin)
+        {
             return 0;
+        }
         else if (resistance > this->_pot0ResistanceRmax)
+        {
             return 256;
-
+        }
         return (uint16_t)((((resistance - this->_pot0ResistanceRW) / (this->_pot0ResistanceRAB)) * (float)256) + 0.5);
     }
-}
-
-float MCP4251::DigitalPotPositionToResistance(bool potNum, uint16_t position)
-{
-    if (potNum)
+    else if(potNum == 1)
     {
-
-        if (position < 0)
-            return this->_pot1ResistanceRmin;
-        else if (position > 256)
-            return this->_pot1ResistanceRmax;
-
-        return ((this->_pot1ResistanceRAB / 256) * (float)position) + this->_pot1ResistanceRW;
+        if (resistance <= this->_pot1ResistanceRmin)
+        {
+            return 0;
+        }
+        else if (resistance > this->_pot1ResistanceRmax)
+        {
+            return 256;
+        }
+        return (uint16_t)((((resistance - this->_pot1ResistanceRW) / (this->_pot1ResistanceRAB)) * (float)256) + 0.5);
+    }
+    else if(potNum == 2)
+    {
+        if (resistance <= this->_pot2ResistanceRmin)
+        {
+            return 0;
+        }
+        else if (resistance > this->_pot2ResistanceRmax)
+        {
+            return 256;
+        }
+        return (uint16_t)((((resistance - this->_pot2ResistanceRW) / (this->_pot2ResistanceRAB)) * (float)256) + 0.5);
     }
     else
     {
-        if (position < 0)
-            return this->_pot0ResistanceRmin;
-        else if (position > 256)
-            return this->_pot0ResistanceRmax;
+        if (resistance <= this->_pot3ResistanceRmin)
+        {
+            return 0;
+        }
+        else if (resistance > this->_pot3ResistanceRmax)
+        {
+            return 256;
+        }
+        return (uint16_t)((((resistance - this->_pot3ResistanceRW) / (this->_pot3ResistanceRAB)) * (float)256) + 0.5);
+    }
+}
 
+float MCP4251::DigitalPotPositionToResistance(uint8_t potNum, uint16_t position)
+{
+    if(potNum == 0)
+    {
+        if (position < 0)
+        {
+            return this->_pot0ResistanceRmin;
+        }
+        else if (position > 256)
+        {
+            return this->_pot0ResistanceRmax;
+        }
         return ((this->_pot0ResistanceRAB / 256) * (float)position) + this->_pot0ResistanceRW;
+    }
+    else if(potNum == 1)
+    {
+        if (position < 0)
+        {
+            return this->_pot1ResistanceRmin;
+        }
+        else if (position > 256)
+        {
+            return this->_pot1ResistanceRmax;
+        }
+        return ((this->_pot1ResistanceRAB / 256) * (float)position) + this->_pot1ResistanceRW;
+    }
+    else if(potNum == 2)
+    {
+
+        if (position < 0)
+        {
+            return this->_pot2ResistanceRmin;
+        }
+        else if (position > 256)
+        {
+            return this->_pot2ResistanceRmax;
+        }
+        return ((this->_pot2ResistanceRAB / 256) * (float)position) + this->_pot2ResistanceRW;
+    }
+    else 
+    {
+        if (position < 0)
+        {
+            return this->_pot3ResistanceRmin;
+        }
+        else if (position > 256)
+        {
+            return this->_pot3ResistanceRmax;
+        }
+        return ((this->_pot3ResistanceRAB / 256) * (float)position) + this->_pot3ResistanceRW;
     }
 }

--- a/src/MCP4251.h
+++ b/src/MCP4251.h
@@ -7,15 +7,20 @@
 #include "Wprogram.h"
 #endif
 
-#define ADDRESS_WIPER_0 B00000000
-#define ADDRESS_WIPER_1 B00010000
-#define ADDRESS_TCON B01000000
-#define ADDRESS_STATUS B01010000
+#define ADDRESS_WIPER_0   B00000000
+#define ADDRESS_WIPER_1   B00010000
+#define ADDRESS_TCON0     B01000000
 
-#define COMMAND_WRITE B00000000
+#define ADDRESS_WIPER_2   B01100000
+#define ADDRESS_WIPER_3   B01110000
+#define ADDRESS_TCON1     B10100000
+
+#define ADDRESS_STATUS    B01010000
+
+#define COMMAND_WRITE     B00000000
 #define COMMAND_INCREMENT B00000100
 #define COMMAND_DECREMENT B00001000
-#define COMMAND_READ B00001100
+#define COMMAND_READ      B00001100
 
 #define DUMMY_DATA B11111111
 
@@ -23,54 +28,66 @@
 
 #define BITMASK_POT0_STARTUP B00001000
 #define BITMASK_POT1_STARTUP B10000000
+#define BITMASK_POT2_STARTUP B00001000
+#define BITMASK_POT3_STARTUP B10000000
+
 #define BITMASK_POT0_B_TERMINAL_CONNECT B00000001
 #define BITMASK_POT1_B_TERMINAL_CONNECT B00010000
+#define BITMASK_POT2_B_TERMINAL_CONNECT B00000001
+#define BITMASK_POT3_B_TERMINAL_CONNECT B00010000
+
 #define BITMASK_POT0_WIPER_TERMINAL_CONNECT B00000010
 #define BITMASK_POT1_WIPER_TERMINAL_CONNECT B00100000
+#define BITMASK_POT2_WIPER_TERMINAL_CONNECT B00000010
+#define BITMASK_POT3_WIPER_TERMINAL_CONNECT B00100000
+
 #define BITMASK_POT0_A_TERMINAL_CONNECT B00000100
 #define BITMASK_POT1_A_TERMINAL_CONNECT B01000000
-
+#define BITMASK_POT2_A_TERMINAL_CONNECT B00000100
+#define BITMASK_POT3_A_TERMINAL_CONNECT B01000000
 
 
 class MCP4251
 {
 public:
   // Constructor
-  MCP4251(uint8_t slaveSelectPin, float pot0ResistanceRmax, float pot0ResistanceRmin, float pot1ResistanceRmax, float pot1ResistanceRmin);
+  MCP4251(uint8_t slaveSelectPin, float pot0ResistanceRmax, float pot0ResistanceRmin, float pot1ResistanceRmax, float pot1ResistanceRmin, float pot2ResistanceRmax, float pot2ResistanceRmin, float pot3ResistanceRmax, float pot3ResistanceRmin);
   void begin();
-  void DigitalPotWiperIncrement(bool potNum);
-  void DigitalPotWiperDecrement(bool potNum);
-  void DigitalPotSetWiperPosition(bool potNum, uint16_t value); // Need confirmation if it is working
-  void DigitalPotSetWiperMin(bool potNum);
-  void DigitalPotSetWiperMax(bool potNum);
-  void DigitalPotSetWiperMid(bool potNum);
+  void DigitalPotWiperIncrement(uint8_t potNum);
+  void DigitalPotWiperDecrement(uint8_t potNum);
+  void DigitalPotSetWiperPosition(uint8_t potNum, uint16_t value); // Need confirmation if it is working
+  void DigitalPotSetWiperMin(uint8_t potNum);
+  void DigitalPotSetWiperMax(uint8_t potNum);
+  void DigitalPotSetWiperMid(uint8_t potNum);
 
-  uint16_t DigitalPotReadWiperPosition(bool potNum);
+  uint16_t DigitalPotReadWiperPosition(uint8_t potNum);
   uint16_t DigitalPotReadTconRegister();
   uint16_t DigitalPotReadStatusRegister();
 
-  void DigitalPotWriteTconRegister(uint16_t value);
+  void DigitalPotWriteTcon0Register(uint16_t value);
+  void DigitalPotWriteTcon1Register(uint16_t value);
 
-  void DigitalPotStartup(bool potNum);
-  void DigitalPotShutdown(bool potNum);
+  void DigitalPotStartup(uint8_t potNum);
+  void DigitalPotShutdown(uint8_t potNum);
 
-  void DigitalPotTerminalBConnect(bool potNum);
-  void DigitalPotTerminalBDisconnect(bool potNum);
+  void DigitalPotTerminalBConnect(uint8_t potNum);
+  void DigitalPotTerminalBDisconnect(uint8_t potNum);
 
-  void DigitalPotTerminalAConnect(bool potNum);
-  void DigitalPotTerminalADisconnect(bool potNum);
+  void DigitalPotTerminalAConnect(uint8_t potNum);
+  void DigitalPotTerminalADisconnect(uint8_t potNum);
 
-  void DigitalPotWiperConnect(bool potNum);
-  void DigitalPotWiperDisconnect(bool potNum);
+  void DigitalPotWiperConnect(uint8_t potNum);
+  void DigitalPotWiperDisconnect(uint8_t potNum);
 
   void DigitalPotInitTcon();
 
-  uint16_t DigitalPotResistanceToPosition(bool potNum, float resistance);
-  float DigitalPotPositionToResistance(bool potNum, uint16_t position);
+  uint16_t DigitalPotResistanceToPosition(uint8_t potNum, float resistance);
+  float DigitalPotPositionToResistance(uint8_t potNum, uint16_t position);
 
 private:
   uint8_t _slaveSelectPin;
-  float _pot0ResistanceRmax, _pot0ResistanceRmin, _pot0ResistanceRAB, _pot0ResistanceRW, _pot1ResistanceRmax, _pot1ResistanceRmin, _pot1ResistanceRAB, _pot1ResistanceRW;
+  float _pot0ResistanceRmax, _pot0ResistanceRmin, _pot0ResistanceRAB, _pot0ResistanceRW, _pot1ResistanceRmax, _pot1ResistanceRmin, _pot1ResistanceRAB, _pot1ResistanceRW, \
+        _pot2ResistanceRmax, _pot2ResistanceRmin, _pot2ResistanceRAB, _pot2ResistanceRW, _pot3ResistanceRmax, _pot3ResistanceRmin, _pot3ResistanceRAB, _pot3ResistanceRW;
 
 };
 


### PR DESCRIPTION
**Context:**
I noticed that when using this library I could only control 2/4 Potentiometers.
I have added support for the other two. 

Important mentions:
1. All bools have now been replaced with uint8_t's
2. I have added an extra function to access TCON1
3. Some code was cleaned up
4. There was a mismatch in type for DigitalPotSetWiperPosition, this caused code not to compile on Platformio I have made it a uint16_t